### PR TITLE
Added switch-window (visual replacement for C-x o).

### DIFF
--- a/README.org
+++ b/README.org
@@ -87,6 +87,7 @@ Most of the following packages are available in [[https://github.com/milkypostma
    - [[http://www.emacswiki.org/emacs/ImenuMode][imenu]] - =[built-in]= Menus for accessing locations in documents.
    - [[https://github.com/vitoshka/imenu-anywhere][imenu-anywhere]] - IDO/Helm imenu tag selection across all buffers with the same mode.
    - [[https://github.com/dustinlacewell/emacs-minimap][Minimap]] - A SublimeText-style minimap sidebar.
+   - [[https://github.com/dimitri/switch-window][switch-window]] - A visual replacement for =C-x o=.
 
 ** Project management
 


### PR DESCRIPTION
This is possibly my most-used package, as I'm constantly switching windows and usually run with a 3+ window split setup.

There's a screenshot and a short explanation at the [package homepage](http://tapoueh.org/emacs/switch-window.html). After hitting `C-x o`, you hit the number of the window you want to switch to.
