### PR TITLE
Add ESUP, Emacs Start Up Profiler

### DIFF
--- a/README.org
+++ b/README.org
@@ -367,6 +367,7 @@ External Guides:
 
     - [[https://github.com/jwiegley/use-package][use-package]] - A declaration macro to isolate package configuration in a way that is performance-oriented and tidy.
       - [[https://github.com/edvorg/req-package][req-package]] - A use-package wrapper for package runtime dependencies management.
+    - [[https://github.com/jschaf/esup][ESUP]] - Emacs Start Up Profiler.  Benchmark Emacs Startup time without ever leaving your Emacs.
 
 ** Library
 


### PR DESCRIPTION
Nice package to discover what's causing different part of ones emacs.d to slow stuff down when loading up emacs.
