### PR TITLE
Add cargo.el to Rust

### DIFF
--- a/README.org
+++ b/README.org
@@ -328,6 +328,7 @@ External Guides:
     - [[https://github.com/rust-lang/rust-mode][rust-mode]] - An Emacs major mode for editing Rust code.
     - [[https://github.com/flycheck/flycheck-rust][flycheck-rust]] - Better Rust/Cargo support for Flycheck.
     - [[https://github.com/racer-rust/emacs-racer][emacs-racer]] - Racer support for Emacs
+    - [[https://github.com/attichacker/cargo.el][cargo.el]] - Cargo support for Emacs
 
 *** Nim
 


### PR DESCRIPTION
A minor mode for managing a Rust Cargo project.