### PR TITLE
Add lentic to Editing section

### DIFF
--- a/README.org
+++ b/README.org
@@ -379,6 +379,7 @@ External Guides:
    - [[https://github.com/rejeep/drag-stuff.el][Drag Stuff]] - Drag Stuff is a minor mode for Emacs that makes it possible to drag stuff (words, region, lines) around in Emacs.
    - [[https://github.com/magnars/expand-region.el][expand-region.el]] - Increase selected region by semantic units.
    - [[https://github.com/magnars/multifiles.el][multifiles.el]] - View and edit parts of multiple files in one buffer.
+   - [[https://github.com/phillord/lentic][lentic]] -  Create views of the same content in two Emacs buffers.
 
 *** Kill-ring
 


### PR DESCRIPTION
Lentic allows two buffers to share the same or similar content but otherwise operate independently.
Different buffers can be in the same mode, with different locations of point, even different text sizes 
-- in effect, providing multiple persistent views.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>