### PR TITLE
Add links to some packages

### DIFF
--- a/README.org
+++ b/README.org
@@ -105,6 +105,8 @@ Most of the following packages are available in [[https://github.com/milkypostma
    - [[https://github.com/chrisdone/god-mode][god-mode]] - Global minor mode for entering Emacs commands without modifier keys.
    - [[https://github.com/ergoemacs/ergoemacs-mode][ergoemacs-mode]] - Global minor mode to use both common interface keys and ergonomic keys for emacs.
    - [[https://github.com/pashinin/workgroups2][workgroups2]] - Session manager, saves all your opened buffers, their location and sizes on disk to restore later
+   - [[https://github.com/mrkkrp/modalka][modalka]] - Introduce native modal editing of your own design
+   - [[https://github.com/mrkkrp/ace-popup-menu][ace-popup-menu]] - Replace GUI popup menu with something more efficient
 
 ** File Manager
 
@@ -168,6 +170,7 @@ Most of the following packages are available in [[https://github.com/milkypostma
 
 *** Code Folding
 
+    - [[https://github.com/mrkkrp/vimish-fold][vimish-fold]] - Vim-like text folding
     - [[http://www.emacswiki.org/emacs/HideShow][hideshow]] - =[built-in]= Folding regions by balanced-expression code.
       - [[http://www.emacswiki.org/emacs/download/hideshowvis.el][hideshowvis]] - Based on =hideshow=, just display its nodes on fringe.
 
@@ -220,6 +223,7 @@ Most of the following packages are available in [[https://github.com/milkypostma
 
      - [[http://common-lisp.net/project/slime/][SLIME]] - A fully-functional IDE for Common Lisp development, with debugger, REPL.
        - [[https://github.com/capitaomorte/sly][SLY]] - A fork of SLIME.
+     - [[https://github.com/mrkkrp/common-lisp-snippets][common-lisp-snippets]] - Yasnippets for Common Lisp
 
 **** Scheme
 
@@ -388,6 +392,8 @@ External Guides:
    - [[https://github.com/magnars/expand-region.el][expand-region.el]] - Increase selected region by semantic units.
    - [[https://github.com/magnars/multifiles.el][multifiles.el]] - View and edit parts of multiple files in one buffer.
    - [[https://github.com/phillord/lentic][lentic]] -  Create views of the same content in two Emacs buffers.
+   - [[https://github.com/mrkkrp/fix-word][fix-word]] - Transform words in Emacs (upcase, downcase, capitalize)
+   - [[https://github.com/mrkkrp/zzz-to-char][zzz-to-char]] - Fancy replacement for `zap-to-char`
 
 *** Kill-ring
 
@@ -577,6 +583,7 @@ External Guides:
    - [[http://www.gnuvola.org/software/gnugo/][gnugo.el]] - The official Emacs Lisp interface to GNU Go.
    - [[https://github.com/ch11ng/exwm][exwm]] - EXWM turns Emacs into a full-featured tiling X window manager.
    - [[https://github.com/rexim/pacmacs.el][Pacmacs]] - Pacman-like game for Emacs.
+   - [[https://github.com/hagleitn/speed-type][speed-type]] - Practice speed/touch typing in Emacs
    - [[https://github.com/kuanyui/fsc.el][fsc.el]] - Fuck the Speeching Censorship!
 
 ** Starter Kit


### PR DESCRIPTION
These are most useful (I deduce from GitHub stars and number of downloads from MELPA) and probably most understandable :-D from my packages. I've placed them at the end of every category because I don't think they are really popular even when I think they are better than more popular alternatives. Exception is made for `vimish-fold`, which seems to be better than `hideshow` according to *actual user feedback*. It seems to gain some popularity nowadays.

Package `speed-type` is not mine, but I think it's pretty good, so I added it too.
