### PR TITLE
add "jump to definition" to programming section

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,6 +16,7 @@ Most of the following packages are available in [[https://github.com/milkypostma
     - [[#completion][Completion]]
     - [[#code-folding][Code Folding]]
     - [[#error-checking][Error Checking]]
+    - [[#jump-to-definition][Jump to Definition]]
   - [[#programming-language][Programming Language]]
     - [[#cc][C/C++]]
     - [[#python][Python]]
@@ -180,6 +181,10 @@ Most of the following packages are available in [[https://github.com/milkypostma
 
     - [[http://www.emacswiki.org/emacs/FlyMake][FlyMake]] - =[built-in]= on-the-fly syntax checks on files using external tools.
     - [[https://github.com/flycheck/flycheck][Flycheck]] - Modern on-the-fly syntax checking meant to be a replacement to =FlyMake=
+    
+*** Jump to Definition
+    - [[https://github.com/jacktasia/dumb-jump][Dumb Jump]] - easy jump to definition package for multiple languages using `ag` or `grep`
+    - [[http://www.gnu.org/software/global/]][GNU Global]] - advanced source code tagging system with jump to definition functionality 
 
 ** Programming Language
 

--- a/README.org
+++ b/README.org
@@ -183,8 +183,8 @@ Most of the following packages are available in [[https://github.com/milkypostma
     - [[https://github.com/flycheck/flycheck][Flycheck]] - Modern on-the-fly syntax checking meant to be a replacement to =FlyMake=
     
 *** Jump to Definition
-    - [[https://github.com/jacktasia/dumb-jump][Dumb Jump]] - easy jump to definition package for multiple languages using `ag` or `grep`
-    - [[http://www.gnu.org/software/global/]][GNU Global]] - advanced source code tagging system with jump to definition functionality 
+    - [[https://github.com/jacktasia/dumb-jump][Dumb Jump]] - easy jump to definition package for multiple languages using =ag= or =grep=
+    - [[http://www.gnu.org/software/global/][GNU Global]] - advanced source code tagging system with jump to definition functionality 
 
 ** Programming Language
 


### PR DESCRIPTION
This adds a "jump to definition" section to the programming section. This functionality is often provided via language specific packages that provide additional features for that language. I think it's worth considering adding a section for packages that are devoted to this type of functionality and support multiple languages. Full disclosure: I made Dump Jump.