### PR TITLE
Remove helm-ack

### DIFF
--- a/README.org
+++ b/README.org
@@ -454,7 +454,6 @@ External Guides:
 **** Ack
 
     - [[http://nschum.de/src/emacs/full-ack/][full-ack]] - An Emacs front-end for ack.
-    - [[https://github.com/syohex/emacs-helm-ack][helm-ack]] - Use Ack with Helm interface.
     - [[https://github.com/leoliu/ack-el][ack-el]] - Emacs Interface to Ack-like Tools.
 
 **** Ag


### PR DESCRIPTION
helm-ack is no longer maintained. helm-ag can be available instead of helm-ack.