### PR TITLE
Remove Google Client link

### DIFF
--- a/README.org
+++ b/README.org
@@ -489,7 +489,6 @@ External Guides:
 
     - [[https://github.com/Malabarba/emacs-google-this][google-this]] - A set of functions and bindings to google under point.
     - [[https://github.com/atykhonov/google-translate][google-translate]] - Interface to Google Translate.
-    - [[http://emacspeak.googlecode.com/svn/trunk/lisp/g-client/][g-client]] - Google client for Emacs.
 
 *** Blog
     - [[https://github.com/nibrahim/Hyde][Hyde]] - An Emacs mode to manage [[https://jekyllrb.com/][Jekyll]] blogs


### PR DESCRIPTION
Removed link as it resolves to a 404 now