### PR TITLE
Add RefTeX

### DIFF
--- a/README.org
+++ b/README.org
@@ -540,6 +540,7 @@ External Guides:
 
    - [[https://www.gnu.org/software/auctex/][AUCTeX]] - an extensible package for writing and formatting TeX files.
    - [[http://www.emacswiki.org/emacs/LaTeXPreviewPane][latex-preview-pane]] is a minor mode for Emacs that enables you to preview your LaTeX files directly in Emacs.
+   - [[https://www.gnu.org/software/auctex/reftex.html][RefTeX]] - =[built-in]= Adds support for labels, references, citations, and index entries.
 
 ** PDF
    - [[https://github.com/politza/pdf-tools][PDF Tools]] - major mode for rendering PDF files, much better than DocView, and has much richer set of features


### PR DESCRIPTION
Adds RefTeX (https://www.gnu.org/software/auctex/reftex.html) to the LaTeX section

_RefTEX is a specialized package for support of labels, references, citations, and the indices in LATEX._