### PR TITLE
Add scimax to starter kits.

### DIFF
--- a/README.org
+++ b/README.org
@@ -754,6 +754,7 @@ External Guides:
    - [[https://github.com/rdallasgray/graphene][Graphene]] - A set of defaults for Emacs, for refugees from GUI text editors.
    - [[https://github.com/bodil/ohai-emacs][Ohai Emacs]] - The finest hand crafted artisanal emacs.d for your editing pleasure.
    - [[http://emacs-bootstrap.com/][Emacs-Bootstrap]] - Your on-the-fly Emacs development environment!
+   - [[https://github.com/jkitchin/scimax][Scimax]] - An Emacs starter kit for scientists and engineers with a focus on Org-Mode.
 
 ** Noteworthy Configurations
  


### PR DESCRIPTION
Scimax is a starter kit for scientists and engineers with lots of goodies for Org-Mode.