### PR TITLE
Add Zoom

### DIFF
--- a/README.org
+++ b/README.org
@@ -131,6 +131,7 @@ Most of the following packages are available in [[https://github.com/melpa/melpa
    - [[https://github.com/ReanGD/emacs-multi-compile][multi-compile]] - Multi target interface to compile.
    - [[https://github.com/rakanalh/emacs-dashboard][Dashboard]] - A startup dashboard which provides certain information about your recent Emacs activities.
    - [[HTTPS://github.com/ch11ng/exwm][EXWM]] - EXWM turns Emacs into a full-featured tiling X window manager.
+   - [[https://github.com/cyrus-and/zoom][Zoom]] - Fixed and automatic balanced window layout for Emacs.
 
 ** File Manager
 


### PR DESCRIPTION
This PR adds [Zoom][1]: Fixed and automatic balanced window layout for Emacs.

[1]: https://github.com/cyrus-and/zoom