### PR TITLE
Add Frontmacs to 'Starter Kit' Section

### DIFF
--- a/README.org
+++ b/README.org
@@ -781,6 +781,7 @@ External Guides:
    - [[https://github.com/bodil/ohai-emacs][Ohai Emacs]] - The finest hand crafted artisanal emacs.d for your editing pleasure.
    - [[http://emacs-bootstrap.com/][Emacs-Bootstrap]] - Your on-the-fly Emacs development environment!
    - [[https://github.com/jkitchin/scimax][Scimax]] - An Emacs starter kit for scientists and engineers with a focus on Org-Mode.
+   - [[https://github.com/thefrontside/frontmacs][Frontmacs]] - A package-based, web-centric, customizable, awesome-by-default, acceptance-tested Emacs distribution.
 
 ** Noteworthy Configurations
 


### PR DESCRIPTION
Frontmacs is a package-based, web-centric, customizable,
awesome-by-default, acceptance-tested Emacs distribution curated by
your friends at Frontside.

We've been using Emacs for years here at Frontside, and have finally
decided to share the configuration for our favorite editor with the world.

Read more about Frontmacs here:
https://github.com/thefrontside/frontmacs