### PR TITLE
Add Evil bindings modes

### DIFF
--- a/README.org
+++ b/README.org
@@ -121,6 +121,11 @@ Most of the following packages are available in [[https://github.com/melpa/melpa
    - [[https://github.com/dholm/tabbar][tabbar]] - Display a tab bar in the header line.
    - [[https://www.emacswiki.org/emacs/WinnerMode][winner]] - =[built-in]= "Undo"(and "redo") changes in the window configuration with the key commands.
    - [[https://github.com/emacs-evil/evil][Evil]] - An *e* xtensible *vi* *l* ayer: manipulate Emacs with Vi key binding.
+     - [[https://github.com/jojojames/evil-collection][Evil Collection]] - A collection of Evil bindings.
+     - [[https://github.com/emacs-evil/evil-ediff][Evil Ediff]] - Evil bindings for Ediff.
+     - [[https://github.com/emacs-evil/evil-magit][Evil Magit]] - Evil bindings for Magit.
+     - [[https://github.com/JorisE/evil-mu4e][Evil mu4e]] - Evil bindings for mu4e.
+     - [[https://github.com/noctuid/lispyville][LispyVille]] - Evil bindings for lispy-mode.
    - [[https://github.com/abo-abo/hydra][Hydra]] - Make bindings that stick around.
    - [[https://github.com/zk-phi/sublimity][sublimity]] - smooth-scrolling, minimap inspired by the sublime editor.
    - [[https://github.com/knu/elscreen][ElScreen]] - Utility for multiple screens.


### PR DESCRIPTION
Note that most of the effort for writing Evil bindings is focused on Evil Collection, thus the list is unlikely to grow.