### PR TITLE
Add ledger-mode for plain text accounting

### DIFF
--- a/README.org
+++ b/README.org
@@ -772,6 +772,7 @@ External Guides:
 ** Finance
 
    - [[https://github.com/NicolasPetton/elbank][Elbank]] - Personal finances application for Emacs.
+   - [[https://github.com/ledger/ledger-mode][ledger-mode]] - Plain text double-entry accounting in Emacs with [[https://www.ledger-cli.org/][ledger]].
 
 ** Fun
 


### PR DESCRIPTION
Added ledger-mode, a wrapper for the ledger command line utility for plain-text accounting. I ommited the slightly less popular hledger-mode, which is a frontend for hledger, the haskell alternative to ledger.