### PR TITLE
Added in the package general for key-binding packages

### DIFF
--- a/README.org
+++ b/README.org
@@ -149,6 +149,7 @@ Above, all enjoy using Emacs. The community, that more than anything, makes Emac
     - [[https://github.com/mrkkrp/modalka][modalka]] - Introduce native modal editing of your own design.
     - [[https://github.com/xahlee/xah-fly-keys][xah-fly-keys]] - A modal keybinding for emacs (like vim), but based on command frequency and ergonomics.
     - [[https://github.com/ergoemacs/ergoemacs-mode][ergoemacs-mode]] - Global minor mode to use both common interface keys and ergonomic keys for emacs.
+    - [[https://github.com/noctuid/general.el][general]] - A convient, unified interface for key definitions - like use-package but for key-bindings.
 
 ** File Manager
 


### PR DESCRIPTION
I'm starting to try out general (https://github.com/noctuid/general.el#about) and it seems very handy. I noticed that it wasn't on the list so I added it in. Looking at the contribution guidelines, I know that you said that the ordering should be based on the popularity of the package. The correct ordering would be: 

1. Evil
2. Hydra
3. god-mode 
4. general
5. ergoemacs-mode 
6. modalka
7. xah-fly-keys 

But also, I wasn't sure if that meant ordering for the overall list or just inner lists - so I just tacked on general at the end. 
