### PR TITLE
Add pipenv.el under Python

### DIFF
--- a/README.org
+++ b/README.org
@@ -308,6 +308,7 @@ Above, all enjoy using Emacs. The community, that more than anything, makes Emac
     - [[https://github.com/jorgenschaefer/elpy][Elpy]] - An Emacs Python development environment.
     - [[https://github.com/proofit404/anaconda-mode][anaconda-mode]] - Code navigation, documentation lookup and completion for Python.
     - [[https://github.com/porterjamesj/virtualenvwrapper.el][virtualenvwrapper.el]] - Manage virtualenv from inside Emacs.
+    - [[https://github.com/pwalsh/pipenv.el][pipenv.el]] - Integrates pipenv to emacs providing useful commands.
 
 *** Ruby
 


### PR DESCRIPTION
Since pipenv is actually the preferred way to develop with Python, it would be great that people using emacs knows that there is a package to integrate pipenv.