### PR TITLE
Add awesome-tab.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -125,6 +125,7 @@ Above, all enjoy using Emacs. The community, that more than anything, makes Emac
    - [[https://www.emacswiki.org/emacs/Icicles][Icicles]] - An Emacs library that enhances minibuffer completion.
    - [[https://github.com/nonsequitur/smex/][smex]] - A smart M-x enhancement for Emacs.
    - [[https://github.com/dholm/tabbar][tabbar]] - Display a tab bar in the header line.
+   - [[https://github.com/manateelazycat/awesome-tab][awesome-tab]] - Out of box extension to use tab in Emacs, build-in projectile support and many awesome features.
    - [[https://www.emacswiki.org/emacs/WinnerMode][winner]] - =[built-in]= "Undo"(and "redo") changes in the window configuration with the key commands.
    - [[https://github.com/zk-phi/sublimity][sublimity]] - smooth-scrolling, minimap inspired by the sublime editor.
    - [[https://github.com/knu/elscreen][ElScreen]] - Utility for multiple screens.


### PR DESCRIPTION
Out of box extension to use tab in Emacs, build-in projectile support and many awesome features.