### PR TITLE
Added kubernetes-el to the DevOps section

### DIFF
--- a/README.org
+++ b/README.org
@@ -731,7 +731,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/emacsmirror/salt-mode][salt-mode]] - Edit Salt States with GNU Emacs 24.
    - [[https://github.com/Silex/docker.el][docker]] - Emacs interface to Docker, manipulate docker images, containers & more from Emacs.
    - [[https://github.com/syohex/emacs-terraform-mode][terraform-mode]] - Terraform mode to edit terraform files.
-
+   - [[https://github.com/chrisbarrett/kubernetes-el][kubernetes-el]] - A magit-style interface to the Kubernetes command-line client.
 ** Package Management
 
 *** Package Manager


### PR DESCRIPTION
Hey,

Kubernetes-el is a great tool for working with Kubernetes clusters. It provides an interface like *Magit* (<3) to show info about deployments, pods and such, as well as commands you usually perform with *kubectl*.

Link: https://github.com/chrisbarrett/kubernetes-el