### PR TITLE
Add highlight-indent-guides

### DIFF
--- a/README.org
+++ b/README.org
@@ -792,6 +792,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/ryuslash/mode-icons][mode-icons]] - Show icons instead of mode names.
    - [[https://github.com/iqbalansari/emacs-emojify][emojify]] - Display emojis in Emacs.
    - [[https://github.com/manateelazycat/awesome-tray][awesome-tray]] - Display mode-line information at right of minibuffer.
+   - [[https://github.com/DarthFennec/highlight-indent-guides][highlight-indent-guides]] - Highlight indentation.
 
 ** Theme
 


### PR DESCRIPTION
I found this package `highlight-indent-guides` recently. This is very nice to me for editing long YAML, JSON, HTML, JSX, etc.!
So this PR suggests adding the package to the awesome list.

The repository is <https://github.com/DarthFennec/highlight-indent-guides>.

Note:
I added it to the `Appearance` category, but if there is a category more suitable for the package, then please tell me. I'm preparing for a change.