### PR TITLE
Adding `org-sort-tasks` lib.

### DIFF
--- a/README.org
+++ b/README.org
@@ -583,10 +583,10 @@ External Guides:
       - [[https://github.com/Kungsgeten/org-brain][org-brain]] - Org-mode wiki + concept-mapping.
       - [[https://github.com/rexim/org-cliplink][org-cliplink]] - Insert org-mode links from clipboard.
       - [[https://github.com/alphapapa/helm-org-rifle][helm-org-rifle]] - Rifle through your Org buffers and acquire your target.
-      - [[https://github.com/abo-abo/org-download][org-download]] - Drag and drop images to Emacs org-mode
+      - [[https://github.com/abo-abo/org-download][org-download]] - Drag and drop images to Emacs org-mode.
       - [[https://github.com/fniessen/org-html-themes][org-html-themes]] - Export Org mode files into awesome HTML in 2 minutes.
-      - [[https://github.com/alphapapa/org-super-agenda][org-super-agenda]] - Help organize your agenda items into tidy groups
-      - [[https://github.com/weirdNox/org-noter][org-noter]] - Annotate documents with a synchronized org-mode buffer alongside them
+      - [[https://github.com/alphapapa/org-super-agenda][org-super-agenda]] - Help organize your agenda items into tidy groups.
+      - [[https://github.com/weirdNox/org-noter][org-noter]] - Annotate documents with a synchronized org-mode buffer alongside them.
 
     - [[https://github.com/snosov1/toc-org][toc-org]] - Generate TOC for Org files.
 

--- a/README.org
+++ b/README.org
@@ -587,6 +587,7 @@ External Guides:
       - [[https://github.com/fniessen/org-html-themes][org-html-themes]] - Export Org mode files into awesome HTML in 2 minutes.
       - [[https://github.com/alphapapa/org-super-agenda][org-super-agenda]] - Help organize your agenda items into tidy groups.
       - [[https://github.com/weirdNox/org-noter][org-noter]] - Annotate documents with a synchronized org-mode buffer alongside them.
+      - [[https://github.com/felipelalli/org-sort-tasks][org-sort-tasks]] - Functions to keep TODO tasks in orgmode sorted and organized.
 
     - [[https://github.com/snosov1/toc-org][toc-org]] - Generate TOC for Org files.
 


### PR DESCRIPTION
Functions to keep TODO tasks in orgmode sorted and organized.

You can sort an unsorted TODO list using mergesort with `org-sort-tasks`. The fn will try to find which task is more important taking into account deadline, scheduled time, priority and then, if everything is equal, finally ask to the user.

When the list is already sorted, you can use fn `org-insert-sorted-todo-heading` to insert a task in a right position using binary search.