### PR TITLE
Update speed-type repo link to new official source

### DIFF
--- a/README.org
+++ b/README.org
@@ -861,7 +861,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/emacsmirror/gnugo][gnugo]] - Play GNU Go in a buffer.
    - [[https://github.com/codingteam/pacmacs.el][Pacmacs]] - Pacman-like game for Emacs.
    - [[https://github.com/dp12/parrot][parrot]] - Rotate text and Party Parrot at the same time.
-   - [[https://github.com/hagleitn/speed-type][speed-type]] - Practice speed/touch typing in Emacs.
+   - [[https://github.com/parkouss/speed-type][speed-type]] - Practice speed/touch typing in Emacs.
    - [[https://gitlab.com/iankelling/spray][spray]] - A speed reading mode for Emacs.
    - [[https://github.com/kuanyui/fsc.el][fsc.el]] - Fuck the Speeching Censorship!
    - [[https://github.com/bcbcarl/emacs-wttrin][wttrin]] - Emacs frontend for weather web service wttr.in.


### PR DESCRIPTION
The old repo link is no longer the official source, it has moved.