### PR TITLE
Add cmake-ide to C++ section

### DIFF
--- a/README.org
+++ b/README.org
@@ -324,6 +324,7 @@ Above, all enjoy using Emacs. The community, that more than anything, makes Emac
     - [[https://github.com/Lindydancer/cmake-font-lock][cmake-font-lock]] - Enhanced font-lock rules for CMake.
     - [[https://github.com/abo-abo/function-args][function-args]] - visual CEDET enhancements for C++.
     - [[https://www.gnu.org/software/emacs/manual/html_node/ebrowse/index.html][Ebrowse]] - =[built-in]= A C++ class browser.
+    - [[https://github.com/atilaneves/cmake-ide/][cmake-ide]] - Configures other packages to consider compile options like include paths from cmake projects to improve e.g. autocompletion.
 
 *** Python
 


### PR DESCRIPTION
`cmake-ide` is improving autocompletion since it uses the compilation database cmake can provide to consider compile options like include paths, defines and other flags to irony, rtags and other packages. Without it completion might be wrong or incomplete.