### PR TITLE
Add information on powerthesaurus.org integration

### DIFF
--- a/README.org
+++ b/README.org
@@ -574,6 +574,7 @@ External Guides:
     - [[http://www.gnu.org/software/emacs-muse/][Emacs Muse]] - a publishing environment for Emacs.
     - [[https://github.com/rnkn/fountain-mode/][Fountain Mode]] - a full-featured screenwriting environment for GNU Emacs using the Fountain markup format.
     - [[https://github.com/tmalsburg/guess-language.el][guess-language]] - Robust automatic language detection (e.g. Arabic, Czech, Danish, etc).
+    - [[https://github.com/SavchenkoValeriy/emacs-powerthesaurus][emacs-powerthesaurus]] - Powerthesaurus integration for Emacs.
 
 *** Org-mode
 


### PR DESCRIPTION
I suggest adding information on my package [emacs-powerthesaurus](https://github.com/SavchenkoValeriy/emacs-powerthesaurus).

I don't really know which category suites it better. I thought that **Note** would do, but **Integrations** also makes a reasonable choice.