### PR TITLE
Add nix-haskell-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -498,6 +498,7 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
     - [[https://github.com/projectional-haskell/structured-haskell-mode][structured-haskell-mode]] - Minor mode for structured editing of Haskell.
     - [[https://github.com/alanz/HaRe][HaRe]] - Haskell refactoring tool with emacs integration.
     - [[http://www.mew.org/~kazu/proj/ghc-mod/en/][ghc-mod]] - Backend to provide e.g. type information with an emacs frontend.
+    - [[https://github.com/matthewbauer/nix-haskell-mode]] - Nix integration for Haskell development.
 
 #+BEGIN_QUOTE
 External Guides:


### PR DESCRIPTION
Given that many Haskell devs seem to use `nix` and starting Emacs from a `nix-shell` is rather inconvenient, `nix-haskell-mode` is incredibly useful for those people.