### PR TITLE
Move racket into its own category

### DIFF
--- a/README.org
+++ b/README.org
@@ -569,6 +569,10 @@ External Guides:
 
     - [[https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode][Emacs-D-Mode]] - An Emacs major mode for editing D code.
 
+*** Racket
+
+    - [[https://github.com/greghendershott/racket-mode][racket-mode]] - An Emacs major mode for editing Racket code, as well as a major mode for a Racket REPL.
+
 *** Elm
 
     - [[https://github.com/jcollard/elm-mode][elm-mode]] - An Emacs major mode for editing Elm code.

--- a/README.org
+++ b/README.org
@@ -396,6 +396,9 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
 
      - [[https://www.neilvandyke.org/quack/][Quack]] - Enhanced Emacs Support for Editing and Running Scheme Code.
      - [[http://www.nongnu.org/geiser/][Geiser]] - Intergrated development with Guile and Racket.
+
+**** Racket
+
      - [[https://github.com/greghendershott/racket-mode][racket-mode]] - major modes for Racket: Edit and REPL.
 
 **** Clojure
@@ -568,10 +571,6 @@ External Guides:
 *** D
 
     - [[https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode][Emacs-D-Mode]] - An Emacs major mode for editing D code.
-
-*** Racket
-
-    - [[https://github.com/greghendershott/racket-mode][racket-mode]] - An Emacs major mode for editing Racket code, as well as a major mode for a Racket REPL.
 
 *** Elm
 


### PR DESCRIPTION
I initially forked to add racket-mode to the list because I didn't see it on there. Then I realized it was listed under scheme. I think this will help discoverability of racket-mode