### PR TITLE
Add Orderless, a completion style to match search terms in any order.

### DIFF
--- a/README.org
+++ b/README.org
@@ -157,6 +157,7 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
      - Swiper, an Ivy-enhanced alternative to isearch.
    - [[https://github.com/raxod502/prescient.el][prescient.el]] - Fast and intuitive frequency-and-recency-based sorting and filtering for Emacs.
    - [[https://github.com/raxod502/selectrum][selectrum]] - Clean, stable, and intuitive incremental narrowing framework for Emacs.  
+   - [[https://github.com/oantolin/orderless][Orderless]] - Use space-separated search terms in any order when completing with Icomplete or the default interface.
    - [[https://github.com/manateelazycat/snails][Snails]] - A modern, easy-to-expand fuzzy search framework.
    - [[https://www.emacswiki.org/emacs/Icicles][Icicles]] - An Emacs library that enhances minibuffer completion.
    - [[https://github.com/nonsequitur/smex/][smex]] - A smart M-x enhancement for Emacs.


### PR DESCRIPTION
From the README:

This package provides an orderless completion style that divides the pattern
into space-separated components, and matches candidates that match all of the
components in any order. Each component can match in any one of several ways:
literally, as a regexp, as an initialism, in the flex style, or as multiple word
prefixes. By default, regexp and initialism matches are enabled.

A completion style is a back-end for completion and is used from a front-end
that provides a completion UI. Any completion style can be used with the default
Emacs completion UI (sometimes called minibuffer tab completion) or with the
built-in Icomplete package (which is similar to the more well-known Ido
Mode). To use a completion style in this fashion simply add it as an entry in
the variables completion-styles and completion-category-overrides (see their
documentation).