### PR TITLE
Add Icomplete and icomplete-vertical.

### DIFF
--- a/README.org
+++ b/README.org
@@ -150,6 +150,8 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
    - [[https://www.emacswiki.org/emacs/InteractivelyDoThings][IDO]] - =[built-in]= Interactively do things with buffers and files.
      - [[https://github.com/DarwinAwardWinner/ido-completing-read-plus][ido-completing-read+]] - Enhance the built-in ido for completion all over Emacs.
      - [[https://github.com/creichert/ido-vertical-mode.el][ido-vertical-mode]] - Make ido display vertically.
+   - [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Icomplete.html][Icomplete]] - =[built-in]= See the list of candidates while completing for any command. Can be made to behave more like Ido with `M-x fido-mode`.
+     - [[https://github.com/oantolin/icomplete-vertical][icomplete-vertical]] - Make Icomplete display vertically.
    - [[https://github.com/emacs-helm/helm][Helm]] - (Formerly 'Anything') A powerful completion and selection narrowing framework. ( External Guides [[http://tuhdo.github.io/helm-intro.html][1]] )
    - [[https://github.com/abo-abo/swiper][Ivy]] - flexible, simple tools for minibuffer completion in Emacs.
      - Ivy, a generic completion mechanism for Emacs.


### PR DESCRIPTION
Icomplete (built-in) is similar to Ido in that displays a list of candidates
while completing, but unlike Ido, Icomplete works for any completion command by
default.

icomplete-vertical is a third-party package that makes Icomplete display
candidates vertically, like in Ivy or Helm.