### PR TITLE
Add gdscript-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -62,6 +62,7 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
     - [[#lua][Lua]]
     - [[#makefile][Makefile]]
     - [[#sml][SML]]
+    - [[#gdscript][Gdscript]]
     - [[#groovy][Groovy]]
     - [[#kotlin][Kotlin]]
     - [[#r][R]]
@@ -566,6 +567,10 @@ External Guides:
 *** SML
 
     - [[http://www.iro.umontreal.ca/~monnier/elisp/][SML mode]] - a major Emacs mode for editing Standard ML source code.
+
+*** Gdscript
+
+    - [[https://github.com/JustCaptcha/emacs-gdscript-mode][gdscript-mode]] - An Emacs package to get GDScript support and syntax highlighting.
 
 *** Groovy
 

--- a/README.org
+++ b/README.org
@@ -71,6 +71,7 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
     - [[#reasonml][ReasonML]]
     - [[#nim][Nim]]
     - [[#d][D]]
+    - [[#raku][Raku]]
     - [[#elm][Elm]]
     - [[#stan][Stan]]
     - [[#mips-assembly][MIPS Assembly]]
@@ -570,7 +571,7 @@ External Guides:
 
 *** Gdscript
 
-    - [[https://github.com/JustCaptcha/emacs-gdscript-mode][gdscript-mode]] - An Emacs package to get GDScript support and syntax highlighting.
+    - [[https://github.com/godotengine/emacs-gdscript-mode][gdscript-mode]] - An Emacs package to get GDScript support and syntax highlighting.
 
 *** Groovy
 


### PR DESCRIPTION
Added  [emacs-gdscript-mode](https://github.com/godotengine/emacs-gdscript-mode) to the programming language section, as well added missing Raku link to the Table of Contents section.