### PR TITLE
Correct the URL for 0x0

### DIFF
--- a/README.org
+++ b/README.org
@@ -777,7 +777,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
     - [[https://github.com/emacs-pe/jist.el][jist.el]] - Yet another gist client for Emacs.
     - [[https://github.com/theanalyst/ix.el][ix.el]] - Paste to [[http://ix.io/][ix.io]] pastebin.
     - [[https://github.com/etu/webpaste.el][webpaste.el]] - Paste to pastebin-like services.
-    - [[https://git.sr.ht/~pkal/nullpointer-emacs][0x0]] - An emacs frontend to the url shortening service [[https://0x0.st/][0x0.st]].
+    - [[https://gitlab.com/willvaughn/emacs-0x0/][0x0]] - An emacs frontend to the url shortening service [[https://0x0.st/][0x0.st]].
 
 *** Google
 


### PR DESCRIPTION
pkal has written this on his repository that's currently linked:

> [William Vaughn](https://gitlab.com/willvaughn/emacs-0x0) has taken over the development of this package on Gitlab. I do not intend to further work on this repository.

I've corrected the link to Vaughn's repo on Gitlab as provided by Philip.