### PR TITLE
Update & add emacs starter kits

### DIFF
--- a/README.org
+++ b/README.org
@@ -1067,7 +1067,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/editor-bootstrap/emacs-bootstrap][Emacs Bootstrap]] - Your on-the-fly Emacs development environment!
    - [[https://github.com/ianyepan/yay-evil-emacs][Ian's Yay-Evil Distro]] - A lightweight literate Emacs config with even better "better defaults": shipped with a custom theme!
    - [[https://github.com/eschulte/emacs24-starter-kit][Emacs24 Starter Kit]] - A cleaner version of the literate starter kit based on Emacs24 http://eschulte.github.io/emacs24-starter-kit/.
-   - [[https://github.com/technomancy/better-defaults][better-defaults]] - A small number of better defaults for Emacs.
+   - [[https://git.sr.ht/~technomancy/better-defaults][better-defaults]] - A small number of better defaults for Emacs. Previously hosted at [[https://github.com/technomancy/better-defaults][GitHub]].
    - [[https://github.com/xiaohanyu/oh-my-emacs][Oh-My-Emacs]] - Provide an awesome, out-of-box, literate dotemacs for both newbies and nerds.
    - [[https://github.com/senny/cabbage][Cabbage]] - Get the maximum out of emacs http://senny.github.io/cabbage/.
 

--- a/README.org
+++ b/README.org
@@ -1070,6 +1070,8 @@ For additional git related emacs packages to use or to get inspiration from, tak
    - [[https://git.sr.ht/~technomancy/better-defaults][better-defaults]] - A small number of better defaults for Emacs. Previously hosted at [[https://github.com/technomancy/better-defaults][GitHub]].
    - [[https://github.com/xiaohanyu/oh-my-emacs][Oh-My-Emacs]] - Provide an awesome, out-of-box, literate dotemacs for both newbies and nerds.
    - [[https://github.com/senny/cabbage][Cabbage]] - Get the maximum out of emacs http://senny.github.io/cabbage/.
+   - [[https://github.com/daviwil/emacs-from-scratch][Emacs From Scratch]] - Custom Emacs configuration that you can use as inspiration when building your own. There's a YouTube [[https://www.youtube.com/playlist?list=PLEoMzSkcN8oPH1au7H6B7bBJ4ZO7BXjSZ][playlist] showing development of this kit.
+   - [[https://github.com/technomancy/emacs-starter-kit][Emacs Starter Kit] - A prose guide to various packages and settings which can greatly improve the Emacs experience.
 
 #+BEGIN_QUOTE
 - In addition, for an excellent selection of personal .emacs.d configurations, take a look at [[https://github.com/caisah/emacs.dz]].


### PR DESCRIPTION
Update Better Defaults to show new host and add two new kits: Emacs From Scratch and Emacs Starter Kit