### PR TITLE
Add the Emacs Desktop Notification Center

### DIFF
--- a/README.org
+++ b/README.org
@@ -781,6 +781,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
 *** Operating System
     - [[https://github.com/ch11ng/exwm][EXWM]] - EXWM turns Emacs into a full-featured tiling X window manager.
       - [[https://github.com/emacs-helm/helm-exwm][Helm-EXWM]] - EXWM-specific sources for Helm together with an application launchers and switches.
+    - [[https://github.com/sinic/ednc/][EDNC]] - Manage all your desktop notifications without leaving Emacs.
     - [[https://depp.brause.cc/eyebrowse/][Eyebrowse]] - A simple-minded way of managing window configs in emacs.
     - [[https://github.com/emacs-eaf/emacs-application-framework][Emacs Application Framework]] - EAF's extensibility allows one to interact with [[https://riverbankcomputing.com/software/pyqt/intro][PyQt]] GUI applications, so that one can develop any PyQt application and integrate it into Emacs (e.g. web browser, video player, camera, rss reader, etc).
     - [[https://github.com/zk-phi/symon/][Symon]] - Tiny graphical system monitor.


### PR DESCRIPTION
[EDNC](https://github.com/sinic/ednc) might not be especially well-known, but as far as I can tell there's no other package in MELPA that acts as a notification server, so it fills a gap.

I put it next to EXWM, because it's probably most useful for users of that window manager. It's not a requirement, however, so I made the entry a sibling instead of a child.

**Disclosure**: I'm the author of this package.