### PR TITLE
Add "vundo" (undo tree structure navigation)

### DIFF
--- a/README.org
+++ b/README.org
@@ -409,6 +409,7 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
    - [[https://gitlab.com/ideasman42/emacs-undo-fu][undo-fu]] - An undo/redo system that advertises itself as being simpler than Undo Tree.
      - [[https://gitlab.com/ideasman42/emacs-undo-fu-session][undo-fu-session]] - Save undo history across sessions. Intended to work with, but not dependent on =undo-fu=.
    - [[https://github.com/jackkamm/undo-propose-el][undo-propose]] - Navigate the emacs undo history by staging undo's in a temporary buffer.
+   - [[https://github.com/casouri/vundo]][vundo] - Navigate the emacs undo buffer history as a tree-structure.
 
 *** Multiple Major-Mode
 


### PR DESCRIPTION
This package is excellent, allowing quick tree navigation on-top of Emacs built-in undo system.

I've been using it for ~4 months now and since some issues were fixed early on it's been rock solid.

With undo-fu/undo-fu-sessioin/vundo - it it's possible to have undo-tree's functionality but with emacs built-in undo.