### PR TITLE
Add idle-highlight-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -340,6 +340,7 @@ Above all, enjoy using Emacs. The community, that more than anything, makes Emac
     - [[https://github.com/nschum/highlight-symbol.el][highlight-symbol]] - Auto/manually highlight the same symbols in code, navigate in them, or replace string.
     - [[https://github.com/fgeller/highlight-thing.el][highlight-thing]] - Light-weight minor mode to highlight thing under point using built-ins.
     - [[https://github.com/ankurdave/color-identifiers-mode][color-identifiers-mode]] - Color Identifiers is a minor mode for Emacs that highlights each source code identifier uniquely based on its name.
+    - [[https://codeberg.org/ideasman42/emacs-idle-highlight-mode][idle-highlight-mode]] - Light-weight minor mode to automatically highlight the thing at point when idle, with configurable exceptions & behavior.
 
 *** Whitespaces Enhancement
 


### PR DESCRIPTION
Added this package, it has similar goals to `highlight-symbol` but has some advantages since it only operates on visible area(s) instead of using hard-coded number of lines for narrowing, it has more downloads on melpa too, although I don't mean to say the other package is bad, just that this works well for large buffers in my experience.

NOTE: I'm not the original author of the package but I do maintain it.