### PR TITLE
add fzf.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -871,6 +871,7 @@ For additional git related emacs packages to use or to get inspiration from, tak
     - [[https://github.com/dieggsy/esh-autosuggest/][esh-autosuggest]] - Fish-like history autosuggestions in Eshell.
     - [[https://github.com/Ambrevar/emacs-fish-completion][fish-completion]] - Fallback on [[https://fishshell.com/][fish shell]] completion for ~M-x shell~ and Eshell.
     - [[https://github.com/manateelazycat/aweshell][aweshell]] - Awesome shell extension based on eshell with wonderful features!
+    - [[https://github.com/bling/fzf.el][fzf.el]] - An extensible Emacs front-end for [[https://github.com/junegunn/fzf][fzf]].
 
 *** Operating System
     - [[https://github.com/ch11ng/exwm][EXWM]] - EXWM turns Emacs into a full-featured tiling X window manager.


### PR DESCRIPTION
Add `fzf.el` to the **Integration -> Console** section. **Minibuffer -> Fuzzy / Narrowing** didn't seem like the right place because this doesn't do anything with the mini buffer, it's a thin interface on top of `fzf` that runs in a regular buffer. I recommend it as a lightweight alternative to things like `projectile` and `helm` if you find yourself only using a small fraction of the many loc there. 