### PR TITLE
Add hl-indent-scope

### DIFF
--- a/README.org
+++ b/README.org
@@ -331,7 +331,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
 
     - [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Indent-Convenience.html][electric-indent-mode]] - =[built-in]= (enabled by default) Auto-indent current and new lines ([[https://www.emacswiki.org/emacs/AutoIndentation][Emacs Wiki]])
     - [[https://github.com/DarthFennec/highlight-indent-guides][highlight-indent-guides]] - Highlight indentation.
-
+    - [[https://codeberg.org/ideasman42/emacs-hl-indent-scope]] - Highlight indentation using source-code scope (typically defined by brackets).
 
 *** Symbols / Tokens
 

--- a/README.org
+++ b/README.org
@@ -331,7 +331,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
 
     - [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Indent-Convenience.html][electric-indent-mode]] - =[built-in]= (enabled by default) Auto-indent current and new lines ([[https://www.emacswiki.org/emacs/AutoIndentation][Emacs Wiki]])
     - [[https://github.com/DarthFennec/highlight-indent-guides][highlight-indent-guides]] - Highlight indentation.
-    - [[https://codeberg.org/ideasman42/emacs-hl-indent-scope]] - Highlight indentation using source-code scope (typically defined by brackets).
+    - [[https://codeberg.org/ideasman42/emacs-hl-indent-scope][hl-indent-scope]] - Highlight indentation using source-code scope (typically defined by brackets).
 
 *** Symbols / Tokens
 


### PR DESCRIPTION
Add hl-indent-scope which works differently to the existing indentation highlighting packages by using the code's scope

Works with C-like/Lisp-like languages as well as CMake and Python.

To get a quick idea how this package differs from the others on this list see: https://user-images.githubusercontent.com/1869379/182262397-f4dd8950-8554-4cc2-a035-3ee0bace91e1.png