### PR TITLE
Note section reorganised and new snippet package

### DIFF
--- a/README.org
+++ b/README.org
@@ -817,6 +817,8 @@ External Guides:
     - [[https://github.com/rnkn/fountain-mode/][Fountain Mode]] - a full-featured screenwriting environment for GNU Emacs using the Fountain markup format.
     - [[https://github.com/tmalsburg/guess-language.el][guess-language]] - Robust automatic language detection (e.g. Arabic, Czech, Danish, etc).
     - [[https://github.com/SavchenkoValeriy/emacs-powerthesaurus][emacs-powerthesaurus]] - Powerthesaurus integration for Emacs.
+    - [[https://github.com/jrblevin/deft][deft]] - Quickly browse, filter, and edit directories of plain text notes.
+      - [[https://github.com/EFLS/zetteldeft][zetteldeft]] - Extend deft.el and turn it into a basic Zettelkasten note-taking system.
 
 *** Org-mode
 
@@ -838,12 +840,7 @@ External Guides:
       - [[https://github.com/org-roam/org-roam][org-roam]] -  a [[https://roamresearch.com/][Roam]] replica built on top of the all-powerful Org-mode.
       - [[https://github.com/alphapapa/org-ql][org-ql]] - An Org-mode query language, including search commands and saved views.
       - [[https://github.com/nobiot/org-transclusion][org-transclusion]] - Link content between buffers to make multiple changes with one edit.
-
-    - [[https://github.com/snosov1/toc-org][toc-org]] - Generate TOC for Org files.
-
-    - [[https://github.com/jrblevin/deft][deft]] - Quickly browse, filter, and edit directories of plain text notes.
-      - [[https://github.com/EFLS/zetteldeft][zetteldeft]] - Extend deft.el and turn it into a basic Zettelkasten note-taking system.
-
+      - [[https://github.com/snosov1/toc-org][toc-org]] - Generate TOC for Org files.
 
 ** Version control
 

--- a/README.org
+++ b/README.org
@@ -429,7 +429,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
    - [[https://github.com/joaotavora/yasnippet][YASnippets]] - A template system that allows you to type an abbreviation and automatically expand it into function templates.
      - [[https://github.com/abo-abo/auto-yasnippet][auto-yasnippet]] - Advanced copy-paste using Yasnippet.
      - [[https://github.com/mkcms/ivy-yasnippet][ivy-yasnippet]] - Preview yasnippet snippets with ivy.
-
+   - [[https://github.com/minad/tempel][Tempel]]: Template package which uses the syntax of the Emacs Tempo library.
 
 *** Text Conversion
 


### PR DESCRIPTION
Hello,

this PR introduces the following changes:
- Fixed the indentation of toc-org
- Placed deft / zetteldeft above the org subsection as they do not belong to it
- Added an alternative to Yasnippet called Tempel in the snippet section