### PR TITLE
Replace intero with dante for Haskell development

### DIFF
--- a/README.org
+++ b/README.org
@@ -692,7 +692,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
 *** Haskell
 
     - [[https://github.com/haskell/haskell-mode][haskell-mode]] - Major mode for Haskell.
-    - [[https://github.com/chrisdone/intero][intero]] - Complete interactive development program for Haskell.
+    - [[https://github.com/jyp/dante][dante]] - Dante provides a frontend to GHCi features: type-checking, execution, completion and cross referencing. It integrates with standard Emacs tooling as much as possible.
     - [[https://github.com/projectional-haskell/structured-haskell-mode][structured-haskell-mode]] - Minor mode for structured editing of Haskell.
     - [[https://github.com/alanz/HaRe][HaRe]] - Haskell refactoring tool with Emacs integration.
     - [[https://github.com/matthewbauer/nix-haskell-mode]] - Nix integration for Haskell development.


### PR DESCRIPTION
`intero` has been discontinued long time ago, and in the meantime `dante` seems to have taken its place.