### PR TITLE
Add kele.el to DevOps section

### DIFF
--- a/README.org
+++ b/README.org
@@ -1076,6 +1076,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/hcl-emacs/terraform-mode][terraform-mode]] - Terraform mode to edit terraform files.
    - [[https://github.com/kubernetes-el/kubernetes-el][kubernetes-el]] - A magit-style interface to the Kubernetes command-line client.
    - [[https://github.com/abrochard/kubel][kubel]] - Emacs extension for controlling Kubernetes with limited permissions.
+   - [[https://github.com/jinnovation/kele.el][kele.el]] - Nimble, well-integrated Kubernetes cluster management package.
 
 ** Package Management
 


### PR DESCRIPTION
[kele.el](https://github.com/jinnovation/kele.el) is a new Emacs package that provides a performant, scalable layer for Kubernetes cluster management within Emacs. It sets itself apart from existing solutions ([kubernetes-el](https://github.com/kubernetes-el/kubernetes-el) and [kubel](https://github.com/abrochard/kubel)) in the following ways:

- A focus on resource agnosticism: We make every effort to source resource-specific information from the Kubernetes API itself as opposed to hard-coding logic in the Emacs layer;
- A focus on minimal obtrusion and context-switching, i.e. getting out of users' way as quickly as possible.

More comparison notes in the kele.el docs [here](https://jonathanj.in/kele.el/explanations/comparisons/).