### PR TITLE
Add vim-tab-bar

### DIFF
--- a/README.org
+++ b/README.org
@@ -235,6 +235,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
    - [[https://github.com/dholm/tabbar][tabbar]] - Display a tab bar in the header line.
    - [[https://github.com/manateelazycat/awesome-tab][awesome-tab]] - Out of box extension to use tab in Emacs. grouping buffers by projects and many awesome features.
    - [[https://github.com/ema2159/centaur-tabs][centaur-tabs]] - Aesthetic, functional tabs plugin with icons and styles, Helm, Ivy and Projectile integration, supported by many popular themes.
+   - [[https://github.com/jamescherti/vim-tab-bar.el][vim-tab-bar]] - Makes Emacs' built-in tab-bar look like Vim's tabbed browsing interface.
 
 
 *** Navigation


### PR DESCRIPTION
This pull request adds the [vim-tab-bar](https://github.com/jamescherti/vim-tab-bar.el) package which enhances Emacs' built-in tab-bar, giving it a style similar to Vim's tabbed browsing interface. 

It also ensures that the tab-bar's appearance aligns with the current theme's overall color scheme, providing a consistent look for your Emacs tab-bar.
