### PR TITLE
Add compile-angel

### DIFF
--- a/README.org
+++ b/README.org
@@ -518,6 +518,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
     - [[https://github.com/ReanGD/emacs-multi-compile][multi-compile]] - Multi target interface to compile.
     - [[https://codeberg.org/ideasman42/emacs-fancy-compilation][fancy-compilation]] - Output enhancements to compilation-mode (including color support).
     - [[https://github.com/emacsorphanage/quickrun][quickrun]] - Implements run button used in many IDE.
+    - [[https://github.com/jamescherti/compile-angel.el][compile-angel.el]] - A package that ensures all `.el` files are both byte-compiled and native-compiled, significantly speeding up Emacs.
 
 ** Project management
 


### PR DESCRIPTION
Add the compile-angel package.

The compile-angel package automatically byte-compiles and native-compiles Emacs Lisp libraries. It offers:
- (compile-angel-on-load-mode): A global mode that compiles .el files before they are loaded.
- (compile-angel-on-save-local-mode): A local mode that compiles .el files whenever the user saves them.

The compile-angel modes speed up Emacs by ensuring all libraries are byte-compiled and native-compiled. Byte-compilation reduces the overhead of loading Emacs Lisp code at runtime, while native compilation optimizes performance by generating machine code specific to your system.

- [compile-angel.el @GitHub](https://github.com/jamescherti/compile-angel.el)
- [compile-angel.el @MELPA](https://melpa.org/#/compile-angel)
