### PR TITLE
Add inhibit-mouse

### DIFF
--- a/README.org
+++ b/README.org
@@ -207,6 +207,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
    - [[https://github.com/k-talo/volatile-highlights.el][volatile-highlights.el]] - Minor mode for visual feedback on some operations in Emacs.
    - [[https://codeberg.org/ideasman42/emacs-buffer-name-relative][buffer-name-relative]] - Project relative buffer names with optional path abbreviation.
    - [[https://github.com/ichernyshovvv/enlight][enlight]] — Highly customizable startup screen for Emacs.
+   - [[https://github.com/jamescherti/inhibit-mouse.el][inhibit-mouse.el]] — A package that allows disabling mouse input in Emacs. It can help prevent accidental clicks or be used to reinforce a keyboard-centric workflow.
 
 *** Window & Frame Management
     #+begin_quote


### PR DESCRIPTION
The **inhibit-mouse** package allows the disabling of mouse input in Emacs using `inhibit-mouse-mode`.

Instead of modifying the keymap of its own mode as the disable-mouse package does, enabling inhibit-mouse-mode only modifies input-decode-map to disable mouse events, making it more efficient and faster than disable-mouse.

Additionally, the *inhibit-mouse* package allows for the restoration of mouse input when `inhibit-mouse-mode` is disabled.

- [inhibit-mouse.el @GitHub](https://github.com/jamescherti/inhibit-mouse.el)
- [inhibit-mouse.el @MELPA](https://melpa.org/#/inhibit-mouse)
