### PR TITLE
Massive Edit: align, query-replace, visual-replace

### DIFF
--- a/README.org
+++ b/README.org
@@ -389,6 +389,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
       - [[https://github.com/benma/visual-regexp-steroids.el/][visual-regexp-steroids]] - The same as visual-regexp, but use modern regular expressions instead of Emacs-style.
     - [[https://github.com/mkcms/interactive-align][ialign]] - Interactively align lines using a regular expression.
     - [[https://github.com/abo-abo/tiny][tiny]] - Templates based on linear range transformations.
+    - [[https://www.emacswiki.org/emacs/AlignCommands][align]] - =[built-in]= =align= supports aligning with regular text, while =align-regexp= uses regular expressions.
 
 *** Quotes & Parenthesis & Delimiters Handling
 

--- a/README.org
+++ b/README.org
@@ -390,6 +390,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
     - [[https://github.com/mkcms/interactive-align][ialign]] - Interactively align lines using a regular expression.
     - [[https://github.com/abo-abo/tiny][tiny]] - Templates based on linear range transformations.
     - [[https://www.emacswiki.org/emacs/AlignCommands][align]] - =[built-in]= =align= supports aligning with regular text, while =align-regexp= uses regular expressions.
+    - [[https://github.com/szermatt/visual-replace][visual-replace]] - Provides a visual representation of replacetement. Unlike visual-regexp, it uses built-in Emacs functionality.
 
 *** Quotes & Parenthesis & Delimiters Handling
 


### PR DESCRIPTION
## [align](https://www.emacswiki.org/emacs/AlignCommands)

Built-in command for aligning text. Also supports regular expressions.

## [query-replace](https://www.gnu.org/software/emacs/manual/html_node/emacs/Query-Replace.html)

Built-in command for replacing text. Also supports regular expressions.

## [visual-replace](https://github.com/szermatt/visual-replace)

> A nicer interface for query-replace on Emacs

Implements visual commands using built-in functionality.