### PR TITLE
Add minuet-ai.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -860,6 +860,8 @@ External Guides:
     - [[https://github.com/s-kostyaev/ellama][Ellama]] - Emacs plugin for [[https://github.com/ollama/ollama][Ollama]], which has both code completion and refactoring capabilities, running on the CPU and with experimental AMD GPU support.
     - [[https://github.com/ragnard/tabby-mode][tabby-mode]] - Emacs interface for [[https://www.tabbyml.com/][Tabby]], an OpenSource self-hosted coding assistant with support for CPU and AMD GPU.
     - [[https://github.com/copilot-emacs/copilot.el][Copilot.el]] - an Emacs plugin for GitHub Copilot.
+    - [[https://github.com/milanglacier/minuet-ai.el][Minuet-ai.el]] - Minuet offers code completion as-you-type from popular LLMs including OpenAI, Gemini, Claude, Ollama, Llama.cpp, Codestral, and more.
+
 
 *** ChatGPT
 


### PR DESCRIPTION
Minuet is a code-completion plugin provide an overlay-based ghost text interface (similar to copilot). An alternative minibuffer completion interface is also provided. It can works with multiple popular LLMs including OpenAI, Claude, Gemini, and more. The user can also choose local LLMs for code completion including Ollama or Llama.cpp.