### PR TITLE
Add repo-grep

### DIFF
--- a/README.org
+++ b/README.org
@@ -985,6 +985,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
 *** Search
 
     - [[https://github.com/mhayashi1120/Emacs-wgrep][wgrep]] -  Writable grep/ack/ag/pt buffer and apply the changes to files.
+    - [[https://github.com/BHFock/repo-grep][repo-grep]] - Grep through the folder structure of your cloned Git repository, searching for the string under the cursor
 
 **** Ack
 


### PR DESCRIPTION
**repo-grep** offers a recursive grep through the folder structure of your cloned git repository or your svn working copy in Emacs. The default search term is the string under the current cursor position. Interactive modification of the search term is possible, and the search term can include regular expression. Regular expressions can also be configured as pre/suffix for the default search term.

**repo-grep-multi** offers a recursive grep across multiple repositories/folders contained in the same directory as the repository in which the search is initiated.