### PR TITLE
Update wttrin to current Melpa working version  

### DIFF
--- a/README.org
+++ b/README.org
@@ -1280,7 +1280,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/dakra/speed-type][speed-type]] - Practice speed/touch typing in Emacs.
    - [[https://gitlab.com/iankelling/spray][spray]] - A speed reading mode for Emacs.
    - [[https://github.com/kuanyui/fsc.el][fsc.el]] - Fuck the Speeching Censorship!
-   - [[https://github.com/bcbcarl/emacs-wttrin][wttrin]] - Emacs frontend for weather web service wttr.in.
+   - [[https://github.com/cjennings/emacs-wttrin][wttrin]] - Emacs frontend for weather web service wttr.in.
    - [[https://github.com/johanvts/emacs-fireplace][fireplace]] - A cozy fireplace for emacs.
    - [[https://github.com/Fuco1/clippy.el][clippy]] - Show tooltip with function documentation at point.
    - [[http://elpa.gnu.org/packages/landmark.html][Landmark]] - a neural network that trains a robot to find a tree.


### PR DESCRIPTION
Hello. The current version of wttrin on Melpa has changed. The old version broke a while ago. Since then, I've taken over the package, fixed a bunch of bugs, and am adding enhancements. People running across this old link should be pointed to the current version, not the old broken one. Thanks! 