### PR TITLE
Add gtasks

### DIFF
--- a/README.org
+++ b/README.org
@@ -1067,6 +1067,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
     - [[https://github.com/Malabarba/emacs-google-this][google-this]] - A set of functions and bindings to google under point.
     - [[https://github.com/atykhonov/google-translate][google-translate]] - Interface to Google Translate.
     - [[https://github.com/jd/google-maps.el][google-maps]] - Google Maps support for Emacs.
+    - [[https://github.com/thndrbrrr/gtasks][gtasks]] - Google Tasks API library for Emacs.
 
 *** Blog System
 


### PR DESCRIPTION
Add [gtasks](https://github.com/thndrbrrr/gtasks), a Google Tasks API library for Emacs. It provides functions for listing, creating, and modifying tasklists and tasks.