### PR TITLE
feat(README.org): Add diredc, Update Sunrise Commander info

### DIFF
--- a/README.org
+++ b/README.org
@@ -577,7 +577,10 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
    - [[https://github.com/emacsorphanage/direx][Direx]] - directory tree explorer.
    - [[https://codeberg.org/fourier/ztree][ztree]] - Directory tree comparison mode.
    - [[https://github.com/punassuming/ranger.el][Ranger]] - [[http://ranger.nongnu.org/][ranger]] like file manager based on Dired.
-   - [[https://github.com/sunrise-commander/sunrise-commander][Sunrise Commander]] - Twin-pane file manager for Emacs based on Dired and inspired by Midnight Commander.
+   - Midnight Commander emulators
+     - Twin-pane file managers for Emacs, based on Dired and inspired by Midnight Commander.
+     - [[https://github.com/Boruch-Baum/emacs-diredc][diredc]] - Works with modern Emacs versions, and actively maintained.
+     - [[https://github.com/sunrise-commander/sunrise-commander][Sunrise Commander]] - Most recent commit 2021-09.
    - [[https://github.com/Alexander-Miller/treemacs][Treemacs]] - a tree layout file explorer for Emacs.
    - [[https://github.com/sebastiencs/sidebar.el][Sidebar.el]] - A customizable file explorer with git integration for emacs.
    - [[https://github.com/raghavgautam/tramp-hdfs][tramp-hdfs]] - Browse HDFS in Emacs with dired using Tramp.


### PR DESCRIPTION
Personally, I suspect that sunrise commander has been abandoned for several years now, but I haven't researched the issue and contacted the developers, so I'm not going to be the one to suggest removing it from the list.