### PR TITLE
Add emacs-mcp to AI assistant programming section

### DIFF
--- a/README.org
+++ b/README.org
@@ -904,6 +904,7 @@ External Guides:
     - [[https://github.com/emacs-openai/codegpt][codegpt]] - Use GPT-3 inside Emacs
     - [[https://github.com/chep/copilot-chat.el][copilot-chat.el]] - Chat with Github Copilot
     - [[https://github.com/stevemolitor/claude-code.el][claude-code.el]] - An Emacs interface for Claude Code CLI.
+    - [[https://github.com/BuddhiLW/emacs-mcp][emacs-mcp]] - MCP (Model Context Protocol) server for Emacs, enabling AI assistants like Claude to interact with buffers, projects, git, and persistent memory.
 
 ** Session management
 


### PR DESCRIPTION
## Summary

Add [emacs-mcp](https://github.com/BuddhiLW/emacs-mcp) to the AI assistant programming section.

**emacs-mcp** is an MCP (Model Context Protocol) server for Emacs that enables AI assistants like Claude Code to interact with:
- Emacs buffers and project files
- Git status and operations (via Magit integration)
- Project-specific persistent memory (notes, snippets, conventions, decisions)
- User-defined workflows and automation

The package bridges the gap between AI coding assistants and the Emacs editing environment, allowing seamless collaboration.

### Checklist
- [x] Link format follows existing conventions
- [x] Description is concise and informative
- [x] Placed in appropriate section (AI assistant programming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)