### PR TITLE
Add comet.el to Interface Enhancement

### DIFF
--- a/README.org
+++ b/README.org
@@ -205,6 +205,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
    - [[https://github.com/coldnew/linum-relative][linum-relative]] - display relative line number in the left margin in emacs.
    - [[https://github.com/Malabarba/beacon][beacon]] - Never lose your cursor again.
    - [[https://github.com/protesilaos/pulsar][pulsar]] - Highlights current line, an minimal alternative to beacon.
+   - [[https://git.andros.dev/andros/comet.el][comet]] - Animated comet trail effect that follows the cursor between positions.
    - [[https://github.com/emacsorphanage/yascroll][yascroll-el]] - Yet Another Scroll Bar Mode.
    - [[https://github.com/k-talo/volatile-highlights.el][volatile-highlights.el]] - Minor mode for visual feedback on some operations in Emacs.
    - [[https://codeberg.org/ideasman42/emacs-buffer-name-relative][buffer-name-relative]] - Project relative buffer names with optional path abbreviation.


### PR DESCRIPTION
Add [comet.el](https://git.andros.dev/andros/comet.el) to the Interface Enhancement section, next to beacon and pulsar.

**comet.el** provides an animated comet trail effect for the cursor in Emacs. When the cursor moves, a short comet of highlighted characters travels along the geometric line between the old and new positions, then fades away. It handles visual line wrapping correctly and works with both keyboard and mouse movement.

Requires Emacs 29.1+. Licensed under GPL-3.0.