### PR TITLE
Add hackernews-modern to Social Network

### DIFF
--- a/README.org
+++ b/README.org
@@ -1140,6 +1140,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
       - [[https://github.com/atykhonov/emacs-howdoi][howdoi]] - Instant coding answers via Emacs, a way to query Stack Overflow directly from within Emacs.
     - [[https://github.com/austin-----/weibo.emacs][weibo.emacs]] - Sina weibo client in Emacs.
     - [[https://codeberg.org/martianh/mastodon.el][Mastodon.el]] - An Emacs client for Mastodon.
+    - [[https://git.andros.dev/andros/hackernews-modern-el][hackernews-modern]] - Modern, asynchronous Hacker News client with widget-based interface.
 
 *** Web Feed
 


### PR DESCRIPTION
Add [hackernews-modern](https://git.andros.dev/andros/hackernews-modern-el) to the Social Network section.

A modern, asynchronous Hacker News client for Emacs with a widget-based interface. Uses non-blocking requests (2-3s vs ~10s), supports six feeds (top, new, best, ask, show, jobs), and provides clickable title widgets with color-coded metadata.

Requires Emacs 28.1+. Licensed under GPL-3.0.