### PR TITLE
Add vterm-editor to Console section

### DIFF
--- a/README.org
+++ b/README.org
@@ -1006,6 +1006,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
     - [[https://www.emacswiki.org/emacs/AnsiTerm][Term]] - =[built-in]= A terminal emulator in Emacs.
     - [[https://www.emacswiki.org/emacs/MultiTerm][multi-term]] - Managing multiple terminal buffers in Emacs.
     - [[https://github.com/akermu/emacs-libvterm][vterm]] - A fully-fledged terminal emulator inside Emacs based on [[https://github.com/neovim/libvterm][libvterm]].
+      - [[https://git.andros.dev/andros/vterm-editor.el][vterm-editor]] - Compose multi-line text in a full Emacs buffer and send it back to vterm.
     - [[https://codeberg.org/akib/emacs-eat][Eat]] - Emulate A Terminal, in a region, in a buffer and in Eshell.
     - [[https://github.com/purcell/exec-path-from-shell][exec-path-from-shell]] - Get environment variables such as $PATH from the shell for Mac user.
     - [[https://github.com/zwild/eshell-prompt-extras][eshell-prompt-extras]] - Display extra information and color for your eshell prompt.


### PR DESCRIPTION
Add [vterm-editor](https://git.andros.dev/andros/vterm-editor.el) as a sub-entry under vterm in the Console section.

A lightweight extension for vterm that opens a temporary editing buffer with full Emacs capabilities for composing multi-line text, then sends it back to the terminal via bracketed paste. Under 80 lines of code.

Requires Emacs 25.1+ and emacs-libvterm. Licensed under GPL-3.0.