### PR TITLE
Add Thankful Eyes theme to Theme section

### DIFF
--- a/README.org
+++ b/README.org
@@ -1243,6 +1243,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
    - [[https://github.com/rougier/nano-theme][N Λ N O (Nano) Themes]] - /(light/dark)/ A light theme based on Material colors and a dark theme based on Nord colors.
    - [[https://github.com/protesilaos/ef-themes][Ef themes]] - /(light/dark)/ - Colourful and legible themes for GNU Emacs.
    - [[https://github.com/LionyxML/auto-dark-emacs][auto-dark]] - /(automatic theme changer)/ - Not a theme, but an automatic changer tool between any 2 themes, dark/light, following MacOS, Linux or Windows Dark Mode settings.
+   - [[https://github.com/tanrax/thankful-eyes-theme.el][Thankful Eyes]] - /(dark)/ High-contrast theme designed for colour blind or visually impaired users.
 
    #+BEGIN_QUOTE
    The above list contains some of the most popular/installed themes. You can also take a look at [[https://pawelbx.github.io/emacs-theme-gallery/][GNU Emacs Themes Gallery]] for screenshots of almost all available Emacs themes.


### PR DESCRIPTION
Add [Thankful Eyes](https://github.com/tanrax/thankful-eyes-theme.el) to the Theme section.

A dark, high-contrast Emacs theme designed with accessibility in mind for colour blind or visually impaired users.

Licensed under GPL-3.0.