### PR TITLE
Add lobsters.el to Social Network section

### DIFF
--- a/README.org
+++ b/README.org
@@ -1140,6 +1140,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
       - [[https://github.com/atykhonov/emacs-howdoi][howdoi]] - Instant coding answers via Emacs, a way to query Stack Overflow directly from within Emacs.
     - [[https://github.com/austin-----/weibo.emacs][weibo.emacs]] - Sina weibo client in Emacs.
     - [[https://codeberg.org/martianh/mastodon.el][Mastodon.el]] - An Emacs client for Mastodon.
+    - [[https://github.com/tanrax/lobsters.el][lobsters]] - Lobsters client for Emacs.
 
 *** Web Feed
 


### PR DESCRIPTION
Add [lobsters.el](https://github.com/tanrax/lobsters.el) to the Social Network section.

A Lobsters client for Emacs, similar to hackernews.el but for the Lobsters community.

Licensed under GPL-3.0.