### PR TITLE
Add org-social.el to Social Network section

### DIFF
--- a/README.org
+++ b/README.org
@@ -1140,6 +1140,7 @@ For additional git-related emacs packages to use or to get inspiration from, tak
       - [[https://github.com/atykhonov/emacs-howdoi][howdoi]] - Instant coding answers via Emacs, a way to query Stack Overflow directly from within Emacs.
     - [[https://github.com/austin-----/weibo.emacs][weibo.emacs]] - Sina weibo client in Emacs.
     - [[https://codeberg.org/martianh/mastodon.el][Mastodon.el]] - An Emacs client for Mastodon.
+    - [[https://github.com/tanrax/org-social.el][org-social]] - Emacs client for Org Social, a decentralized social network based on Org Mode files over HTTP.
 
 *** Web Feed
 


### PR DESCRIPTION
Add [org-social.el](https://github.com/tanrax/org-social.el) to the Social Network section.

An Emacs client for Org Social, a decentralized social network based on Org Mode files distributed over HTTP. Supports timelines, replies, reactions, polls, notifications, and multi-account management.

Licensed under GPL-3.0.