### PR TITLE
Add buffer-guardian

### DIFF
--- a/README.org
+++ b/README.org
@@ -352,6 +352,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
    - [[https://github.com/jorgenschaefer/typoel][typo.el]] - Emacs extension for typographical editing.
    - [[https://github.com/sulami/literate-calc-mode.el][literate-calc-mode]] - display live =calc= results inline.
    - [[https://github.com/kickingvegas/casual/blob/main/docs/editkit.org][Casual EditKit]] - a Transient user interface library for Emacs editing commands. Included in [[https://github.com/kickingvegas/casual][Casual]].
+   - [[https://github.com/jamescherti/buffer-guardian.el][buffer-guardian]] - Automatically save Emacs buffers without requiring manual intervention. By default, it triggers a save when the user switches to another buffer, switches to another window or frame, Emacs loses focus, or the minibuffer is opened. Beyond standard file buffers, *buffer-guardian* also manages specialized editing buffers such as *org-src* and *edit-indirect*. Additional features, disabled by default, include periodic or idle-time saving of all buffers, automatic exclusion of remote, nonexistent, or large files, and support for custom exclusion rules via regular expressions or predicate functions.
 
 *** Indentation Enhancement
 


### PR DESCRIPTION
This pull request adds buffer-guardian.

The **buffer-guardian** Emacs package provides `buffer-guardian-mode`, a global mode that automatically saves buffers without requiring manual intervention.

**By default, `buffer-guardian-mode` saves file-visiting buffers when:**
- Switching to another buffer.
- Switching to another window or frame.
- The window configuration changes (e.g., window splits).
- The minibuffer is opened.
- Emacs loses focus.

In addition to regular file-visiting buffers, `buffer-guardian-mode` also handles specialized editing buffers used for inline code blocks, such as `org-src` (for Org mode) and `edit-indirect` (commonly used for Markdown source code blocks). These temporary buffers are linked to an underlying parent buffer. Automatically saving them ensures that modifications made within these isolated code environments are correctly propagated back to the original Org or Markdown file.

Git repository: [buffer-guardian.el @GitHub](https://github.com/jamescherti/buffer-guardian.el)
