### PR TITLE
Add kirigami

### DIFF
--- a/README.org
+++ b/README.org
@@ -549,6 +549,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
     - [[https://github.com/emacs-tree-sitter/treesit-fold][treesit-fold]] - Code folding based on the tree-sitter syntax tree, built on top of treesit.el.
     - [[https://github.com/jamescherti/outline-indent.el][outline-indent]] - Fold text based on indentation levels.
     - [[https://github.com/jcfk/savefold.el][savefold]] - Persistence for various Emacs folding systems.
+    - [[https://github.com/jamescherti/kirigami.el][kirigami]] - Unifies text folding by providing commands to open and close folds across many modes.
 
 *** Compiling
 


### PR DESCRIPTION
The **kirigami** Emacs package provides a unified method to fold and unfold text in Emacs across a diverse set of Emacs modes.

**Supported modes include:** `outline-mode`, `outline-minor-mode`, `outline-indent-minor-mode`, `org-mode`, `markdown-mode`, `gfm-mode`, `embark-collect-mode`, `vdiff-mode`, `vdiff-3way-mode`, `hide-ifdef-mode`, `vimish-fold-mode`, `TeX-fold-mode` (AUCTeX), `fold-this-mode`, `origami-mode`, `yafolding-mode`, `folding-mode`, `ts-fold-mode`, `treesit-fold-mode`, and `hs-minor-mode` (hideshow).

With Kirigami, folding key bindings only need to be configured **once**. After that, the same keys work consistently across all supported major and minor modes, providing a unified and predictable experience for opening and closing folds. The available commands include:

- `kirigami-open-fold`: Open the fold at point.
- `kirigami-open-fold-rec`: Open the fold at point recursively.
- `kirigami-close-fold`: Close the fold at point.
- `kirigami-open-folds`: Open all folds in the buffer.
- `kirigami-close-folds`: Close all folds in the buffer.
- `kirigami-toggle-fold`: Toggle the fold at point.

In addition to unified interface, the kirigami package enhances folding behavior in `outline`, `markdown-mode`, and `org-mode` packages. It ensures that deep folds open reliably, allows folds to be closed even when the cursor is positioned inside the content, and ensures that sibling folds at the same level are visible when a sub-fold is expanded. When Kirigami closes outline folds, it preserves the visibility of folded headings in the window. Additionally, it resolves upstream Emacs issues, such as [bug#79286](https://lists.gnu.org/archive/html/bug-gnu-emacs/2025-08/msg01128.html).

Git repository: [kirigami.el @GitHub](https://github.com/jamescherti/kirigami.el)
