### PR TITLE
Add pre-commit-elisp

### DIFF
--- a/README.org
+++ b/README.org
@@ -667,6 +667,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
      - [[https://github.com/cpitclaudel/easy-escape][easy-escape]] - Improve readability of escape characters in ELisp regular expressions.
      - [[https://github.com/xiongtx/eros][eros]] - Evaluation Result OverlayS for Emacs Lisp.
      - [[https://codeberg.org/ideasman42/emacs-elisp-autofmt][elisp-autofmt]] - Auto-format ELisp (with support for formatting the buffer on save).
+     - [[https://github.com/jamescherti/pre-commit-elisp][pre-commit-elisp]] - Git pre-commit hooks that perform automated quality checks on .el files before commits.
 
 *** Web Development
 


### PR DESCRIPTION
The [pre-commit-elisp](https://github.com/jamescherti/pre-commit-elisp) repository offers pre-commit hooks for **Emacs Lisp (Elisp)** projects. These hooks enforce code quality and consistency by performing automated checks on `.el` files prior to committing changes:

* **`elisp-check-parens`**: Validates that all parentheses in `.el` files are correctly balanced.
* **`elisp-check-byte-compile`**: Byte-compile Elisp files to detect compilation errors.
* **`elisp-check-native-compile`**: Native-compile Elisp files to detect compilation errors.
* **`elisp-indent`**: Indent Elisp files according to Emacs Lisp style conventions.

These pre-commit hooks enforce syntactic correctness, successful byte-compilation, and consistent code formatting, ensuring a high standard of code quality and maintainability throughout the repository.