### PR TITLE
Add stripspace

### DIFF
--- a/README.org
+++ b/README.org
@@ -381,6 +381,7 @@ Above all, enjoy using Emacs. The community, more than anything, makes Emacs a g
     - [[https://www.emacswiki.org/emacs/WhiteSpace][whitespace]] - =[built-in]= Visualize blanks (tab/space/newline).
     - [[https://github.com/purcell/whitespace-cleanup-mode][whitespace-cleanup-mode]] - Intelligently call whitespace-cleanup on save.
     - [[https://github.com/lewang/ws-butler][ws-butler]] - Unobtrusively trim extraneous white-space *ONLY* in lines edited.
+    - [[https://github.com/jamescherti/stripspace.el][stripspace]] - Automatically trim trailing whitespace and normalize indentation while preserving cursor position.
 
 *** Delete Enhancement
 


### PR DESCRIPTION
The **[stripspace](https://github.com/jamescherti/stripspace.el)** Emacs package provides `stripspace-local-mode` and `stripspace-global-mode`, which automatically removes trailing whitespace and blank lines at the end of the buffer when saving.

(**Trailing whitespace** refers to any spaces or tabs that appear at the end of a line, beyond the last non-whitespace character. These characters serve no purpose in the content of the file and can cause issues with version control, formatting, or code consistency. Removing trailing whitespace helps maintain clean, readable files.)

If this enhances your workflow, please show your support by **⭐ starring stripspace.el on GitHub** to help more Emacs users discover its benefits.

The *stripspace* Emacs package additionally provides the following features:
- **Restores the cursor column on the current line**, including spaces before the cursor. *This ensures a consistent editing experience and prevents unintended cursor movement when saving a buffer after removing trailing whitespace.*
- **Normalizes indentation** by converting leading tabs to spaces or leading spaces to tabs, without modifying tabs or spaces within the text. (*Disabled by default.*)
- **Restricts trailing whitespace deletion to buffers that were initially clean**. When enabled, trailing whitespace is removed only if the buffer was clean before saving. (*Disabled by default.*)

(By default, `stripspace-global-mode` enables stripspace in all modes except those listed in the `stripspace-global-mode-exclude-modes` variable. By default, the excluded modes are: *view-mode*, *special-mode*, *minibuffer-mode*, *comint-mode*, *term-mode*, *eshell-mode*, *diff-mode*, *org-agenda-mode*, *message-mode*, and *markdown-mode*. **Markdown-mode is excluded by default because** trailing spaces are often used intentionally for line breaks in Markdown.)